### PR TITLE
upgrade: custom_lint 0.7.3

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,7 +12,7 @@
 node_modules/
 
 # Build
-examples/nilts_example/build/
+**/build/
 
 # CHANGELOG
 **/CHANGELOG.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,9 +44,24 @@ If you are not familiar with Melos, you should read [Melos documentation](https:
 You should run only `melos bootstrap` and `melos prepare` commands.
 
 ```bash
-// You can use `melos bs` instead
+# You can use `melos bs` instead
 melos bootstrap
 melos prepare
+```
+
+### Setup Node.js packages (optional)
+
+This is optional because nilts can detect not formatted files on CI.
+
+If you want to format YAML, Markdown, XML, or JSON files, you can use prepared Node.js packages.
+nilts uses [Prettier](https://prettier.io) packages to format these files.
+These packages are managed by [bun](https://bun.sh/) whose version is defined on [`.tool-versions`](https://github.com/dassssshers/nilts/blob/main/.tool-versions) file.
+
+```bash
+# Install packages
+bun i
+# Format files
+bun fmt
 ```
 
 ## Create a branch and make commit your changes

--- a/examples/nilts_example/analysis_options.yaml
+++ b/examples/nilts_example/analysis_options.yaml
@@ -1,5 +1,3 @@
-include: ../../analysis_options.yaml
-
 analyzer:
   plugins:
     - custom_lint

--- a/examples/nilts_example/pubspec.yaml
+++ b/examples/nilts_example/pubspec.yaml
@@ -14,8 +14,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  custom_lint: ^0.7.1
-  very_good_analysis: ^7.0.0
+  custom_lint: 0.7.3
 
   nilts:
     path: ../../packages/nilts

--- a/packages/nilts/README.md
+++ b/packages/nilts/README.md
@@ -733,11 +733,15 @@ Upcoming... 🚀
 
 ### Lint rule errors don't appear and quick fixes don't work in IDE
 
+> [!IMPORTANT]
+> This issue is solved on nilts 0.18.3 using custom_lint 0.7.3.
+
 Since custom_lint 0.6.7, the IDE has not shown lint rule errors in some cases.
 
 See also:
 
 - [analysis.setContextRoots failed - RequestErrorCode.PLUGIN_ERROR ProcessException: / No such file or directory / Command: flutter pub get · Issue #270 · invertase/dart_custom_lint](https://github.com/invertase/dart_custom_lint/issues/270)
+- [IntelliJ and Android Studio don't show custom lints · Issue #307 · invertase/dart_custom_lint](https://github.com/invertase/dart_custom_lint/issues/307)
 
 ### Quick fix priorities
 

--- a/packages/nilts/pubspec.yaml
+++ b/packages/nilts/pubspec.yaml
@@ -29,7 +29,7 @@ environment:
 dependencies:
   analyzer: ^7.0.0
   analyzer_plugin: ^0.12.0
-  custom_lint_builder: ^0.7.1
+  custom_lint_builder: ^0.7.3
   meta: ^1.9.1
 
 dev_dependencies:

--- a/packages/nilts_test/pubspec.yaml
+++ b/packages/nilts_test/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 
 environment:
   sdk: '>=3.6.0 <4.0.0'
-  flutter: '>=3.27.1'
+  flutter: '>=3.27.4'
 
 dependencies:
   flutter:
@@ -14,8 +14,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  custom_lint: ^0.7.1
-  very_good_analysis: ^7.0.0
+  custom_lint: 0.7.3
+  very_good_analysis: 7.0.0
 
   nilts:
     path: ../nilts

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,5 +5,5 @@ environment:
   sdk: '>=3.6.0 <4.0.0'
 
 dev_dependencies:
-  melos: ^6.2.0
-  very_good_analysis: ^7.0.0
+  melos: 6.2.0
+  very_good_analysis: 7.0.0


### PR DESCRIPTION
## Overview

- upgrade custom_lint 0.7.3
  - this version is solved the issue that lint warnings are not displayed on IDE.

<!-- Summarize what do you want add in this PR. -->

## Feature type

<!-- Select which type of feature you want to add. -->

- [ ] Lint Rule
- [ ] Quick fix
- [ ] Assist
- [x] Other (Update docs, Configure CI, etc...)