### PR TITLE
feat: add rule for `unstable_enum_values` & `unstable_enum_name`

### DIFF
--- a/packages/nilts/README.md
+++ b/packages/nilts/README.md
@@ -724,7 +724,7 @@ See also:
 <details>
 
 <!-- prettier-ignore-start -->
-- Target SDK     : Any versions nilts supports 
+- Target SDK     : Any versions nilts supports
 - Rule type      : Practice
 - Maturity level : Experimental
 - Quick fix      : ✅
@@ -818,6 +818,7 @@ The `name` property is a string representation of the enum value,
 which can be changed without breaking the code.
 
 **BAD:**
+
 <!-- prettier-ignore-start -->
 ```dart
 void printColorValue(Color color) {
@@ -828,10 +829,6 @@ void printColorValue(Color color) {
 
 **GOOD:**
 
-<!-- prettier-ignore-start -->
-```dart
-if (someValue case final actualValue?) {
-  print('value: $actualValue');
 <!-- prettier-ignore-start -->
 ```dart
 enum Color {
@@ -875,6 +872,7 @@ The `values` property returns a mutable List, which can be modified
 and may cause unexpected behavior.
 
 **BAD:**
+
 <!-- prettier-ignore-start -->
 ```dart
 enum Color { red, green, blue }

--- a/packages/nilts/README.md
+++ b/packages/nilts/README.md
@@ -117,8 +117,8 @@ Some of lint rules support quick fixes on IDE.
 | [shrink_wrapped_scroll_view](#shrink_wrapped_scroll_view)                       | Checks the content of the scroll view is shrink wrapped.                       |  Any versions nilts supports   | Practice  |  Experimental  |    ✅️    |
 | [unnecessary_rebuilds_from_media_query](#unnecessary_rebuilds_from_media_query) | Checks `MediaQuery.xxxOf(context)` or `MediaQuery.maybeXxxOf(context)` usages. |  Any versions nilts supports   | Practice  |  Experimental  |    ✅️    |
 | [unsafe_null_assertion](#unsafe_null_assertion)                                 | Checks usage of the `!` operator for forced type casting.                      |  Any versions nilts supports   | Practice  |  Experimental  |    ✅️    |
-| [unstable_enum_name](#unstable_enum_name)                                       | Checks usage of enum name property.                                            |  Any versions nilts supports   | Practice  |  Experimental  |    ❌    |
-| [unstable_enum_values](#unstable_enum_values)                                   | Checks usage of enum values property.                                          |  Any versions nilts supports   | Practice  |  Experimental  |    ❌    |
+| [unstable_enum_name](#unstable_enum_name)                                       | Checks usage of enum name property.                                            |  Any versions nilts supports   | Practice  |  Experimental  |    ❌     |
+| [unstable_enum_values](#unstable_enum_values)                                   | Checks usage of enum values property.                                          |  Any versions nilts supports   | Practice  |  Experimental  |    ❌     |
 
 ### Details
 

--- a/packages/nilts/README.md
+++ b/packages/nilts/README.md
@@ -120,7 +120,6 @@ Some of lint rules support quick fixes on IDE.
 | [unstable_enum_name](#unstable_enum_name)                                       | Checks usage of enum name property.                                            |  Any versions nilts supports   | Practice  |  Experimental  |    ❌    |
 | [unstable_enum_values](#unstable_enum_values)                                   | Checks usage of enum values property.                                          |  Any versions nilts supports   | Practice  |  Experimental  |    ❌    |
 
-
 ### Details
 
 #### defined_async_callback_type
@@ -890,6 +889,7 @@ void printColors() {
 <!-- prettier-ignore-end -->
 
 **GOOD:**
+
 <!-- prettier-ignore-start -->
 ```dart
 enum Color { red, green, blue }

--- a/packages/nilts/README.md
+++ b/packages/nilts/README.md
@@ -856,7 +856,7 @@ void printColorValue(Color color) {
 
 See also:
 
-- [Enums - Dart language specification](https://dart.dev/language/enums)
+- [Enums | Dart](https://dart.dev/language/enums)
 
 </details>
 

--- a/packages/nilts/README.md
+++ b/packages/nilts/README.md
@@ -117,6 +117,9 @@ Some of lint rules support quick fixes on IDE.
 | [shrink_wrapped_scroll_view](#shrink_wrapped_scroll_view)                       | Checks the content of the scroll view is shrink wrapped.                       |  Any versions nilts supports   | Practice  |  Experimental  |    ✅️    |
 | [unnecessary_rebuilds_from_media_query](#unnecessary_rebuilds_from_media_query) | Checks `MediaQuery.xxxOf(context)` or `MediaQuery.maybeXxxOf(context)` usages. |  Any versions nilts supports   | Practice  |  Experimental  |    ✅️    |
 | [unsafe_null_assertion](#unsafe_null_assertion)                                 | Checks usage of the `!` operator for forced type casting.                      |  Any versions nilts supports   | Practice  |  Experimental  |    ✅️    |
+| [unstable_enum_name](#unstable_enum_name)                                       | Checks usage of enum name property.                                            |  Any versions nilts supports   | Practice  |  Experimental  |    ❌    |
+| [unstable_enum_values](#unstable_enum_values)                                   | Checks usage of enum values property.                                          |  Any versions nilts supports   | Practice  |  Experimental  |    ❌    |
+
 
 ### Details
 
@@ -774,6 +777,7 @@ See also:
 <!-- prettier-ignore-start -->
 ```dart
 final value = someValue!;
+enum Color { red, green, blue }
 ```
 <!-- prettier-ignore-end -->
 
@@ -793,20 +797,115 @@ final value = someValue?.someMethod();
 ```
 <!-- prettier-ignore-end -->
 
+See also:
+
+- [Operators | Dart](https://dart.dev/language/operators)
+- [Patterns | Dart](https://dart.dev/language/patterns)
+
+</details>
+
+#### unstable_enum_name
+
+<details>
+
+<!-- prettier-ignore-start -->
+- Target SDK     : Any versions nilts supports
+- Rule type      : Practice
+- Maturity level : Experimental
+- Quick fix      : ❌
+<!-- prettier-ignore-end -->
+
+**Consider** using a more stable way to handle enum values.
+The `name` property is a string representation of the enum value,
+which can be changed without breaking the code.
+
+**BAD:**
+<!-- prettier-ignore-start -->
+```dart
+void printColorValue(Color color) {
+  print(color.name); // 'red', 'green', 'blue'
+}
+```
+<!-- prettier-ignore-end -->
+
 **GOOD:**
 
 <!-- prettier-ignore-start -->
 ```dart
 if (someValue case final actualValue?) {
   print('value: $actualValue');
+<!-- prettier-ignore-start -->
+```dart
+enum Color {
+  red,
+  green,
+  blue,
+  ;
+
+  String get id => switch (this) {
+    red => 'red',
+    green => 'green',
+    blue => 'blue',
+  };
+}
+
+void printColorValue(Color color) {
+  print(color.id);
 }
 ```
 <!-- prettier-ignore-end -->
 
 See also:
 
-- [Operators | Dart](https://dart.dev/language/operators)
-- [Patterns | Dart](https://dart.dev/language/patterns)
+- [Enums - Dart language specification](https://dart.dev/language/enums)
+
+</details>
+
+#### unstable_enum_values
+
+<details>
+
+<!-- prettier-ignore-start -->
+- Target SDK     : Any versions nilts supports
+- Rule type      : Practice
+- Maturity level : Experimental
+- Quick fix      : ❌
+<!-- prettier-ignore-end -->
+
+**Consider** using a more stable way to handle enum values.
+The `values` property returns a mutable List, which can be modified
+and may cause unexpected behavior.
+
+**BAD:**
+<!-- prettier-ignore-start -->
+```dart
+enum Color { red, green, blue }
+
+void printColors() {
+  for (final color in Color.values) {
+    print(color);
+  }
+}
+```
+<!-- prettier-ignore-end -->
+
+**GOOD:**
+<!-- prettier-ignore-start -->
+```dart
+enum Color { red, green, blue }
+
+void printColors() {
+  final colors = [Color.red, Color.green, Color.blue];
+  for (final color in colors) {
+    print(color);
+  }
+}
+```
+<!-- prettier-ignore-end -->
+
+See also:
+
+- [Enums - Dart language specification](https://dart.dev/language/enums)
 
 </details>
 

--- a/packages/nilts/README.md
+++ b/packages/nilts/README.md
@@ -776,7 +776,6 @@ See also:
 <!-- prettier-ignore-start -->
 ```dart
 final value = someValue!;
-enum Color { red, green, blue }
 ```
 <!-- prettier-ignore-end -->
 

--- a/packages/nilts/lib/nilts.dart
+++ b/packages/nilts/lib/nilts.dart
@@ -14,6 +14,8 @@ import 'package:nilts/src/lints/open_type_hierarchy.dart';
 import 'package:nilts/src/lints/shrink_wrapped_scroll_view.dart';
 import 'package:nilts/src/lints/unnecessary_rebuilds_from_media_query.dart';
 import 'package:nilts/src/lints/unsafe_null_assertion.dart';
+import 'package:nilts/src/lints/unstable_enum_name.dart';
+import 'package:nilts/src/lints/unstable_enum_values.dart';
 import 'package:nilts_core/nilts_core.dart';
 
 /// custom_lint integrates the nilts's plugin from this method on
@@ -46,5 +48,7 @@ class _NiltsLint extends PluginBase {
         const ShrinkWrappedScrollView(),
         UnnecessaryRebuildsFromMediaQuery(_dartVersion),
         const UnsafeNullAssertion(),
+        const UnstableEnumName(),
+        const UnstableEnumValues(),
       ];
 }

--- a/packages/nilts/lib/src/lints/unstable_enum_name.dart
+++ b/packages/nilts/lib/src/lints/unstable_enum_name.dart
@@ -4,7 +4,7 @@ import 'package:custom_lint_builder/custom_lint_builder.dart';
 
 /// A class for `unstable_enum_name` rule.
 ///
-/// This rule checks if `name` property is used to get the name of an enum value.
+/// This rule checks if `name` property is used to get from an enum value.
 ///
 /// - Target SDK     : Any versions nilts supports
 /// - Rule type      : Practice

--- a/packages/nilts/lib/src/lints/unstable_enum_name.dart
+++ b/packages/nilts/lib/src/lints/unstable_enum_name.dart
@@ -1,0 +1,76 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A class for `unstable_enum_name` rule.
+///
+/// This rule checks if `name` property is used to get the name of an enum value.
+///
+/// - Target SDK     : Any versions nilts supports
+/// - Rule type      : Practice
+/// - Maturity level : Experimental
+/// - Quick fix      : ❌
+///
+/// **Consider** using a more stable way to handle enum values.
+/// The `name` property is a string representation of the enum value,
+/// which can be changed without breaking the code.
+///
+/// **BAD:**
+/// ```dart
+/// enum Color { red, green, blue }
+///
+/// void printColorValue(Color color) {
+///   print(color.name); // 'red', 'green', 'blue'
+/// }
+/// ```
+///
+/// **GOOD:**
+/// ```dart
+/// enum Color {
+///   red,
+///   green,
+///   blue,
+///   ;
+///
+///   String get id => switch (this) {
+///     red => 'red',
+///     green => 'green',
+///     blue => 'blue',
+///   };
+/// }
+///
+/// void printColorValue(Color color) {
+///   print(color.id);
+/// }
+/// ```
+///
+/// See also:
+///
+/// - [Enums - Dart language specification](https://dart.dev/language/enums)
+class UnstableEnumName extends DartLintRule {
+  /// Create a new instance of [UnstableEnumName].
+  const UnstableEnumName() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'unstable_enum_name',
+    problemMessage: 'Do not use enum name property',
+    url: 'https://github.com/dassssshers/nilts#unstable_enum_name',
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addPropertyAccess((node) {
+      if (node.propertyName.name == 'name' &&
+          node.target?.staticType?.element is EnumElement) {
+        reporter.atNode(node, _code);
+      }
+    });
+  }
+
+  @override
+  List<Fix> getFixes() => [];
+}

--- a/packages/nilts/lib/src/lints/unstable_enum_name.dart
+++ b/packages/nilts/lib/src/lints/unstable_enum_name.dart
@@ -46,14 +46,14 @@ import 'package:custom_lint_builder/custom_lint_builder.dart';
 ///
 /// See also:
 ///
-/// - [Enums - Dart language specification](https://dart.dev/language/enums)
+/// - [Enums | Dart](https://dart.dev/language/enums)
 class UnstableEnumName extends DartLintRule {
   /// Create a new instance of [UnstableEnumName].
   const UnstableEnumName() : super(code: _code);
 
   static const _code = LintCode(
     name: 'unstable_enum_name',
-    problemMessage: 'Do not use enum name property',
+    problemMessage: 'enum name property is unstable',
     url: 'https://github.com/dassssshers/nilts#unstable_enum_name',
   );
 

--- a/packages/nilts/lib/src/lints/unstable_enum_name.dart
+++ b/packages/nilts/lib/src/lints/unstable_enum_name.dart
@@ -64,10 +64,10 @@ class UnstableEnumName extends DartLintRule {
     CustomLintContext context,
   ) {
     context.registry.addPropertyAccess((node) {
-      if (node.propertyName.name == 'name' &&
-          node.target?.staticType?.element is EnumElement) {
-        reporter.atNode(node, _code);
-      }
+      if (node.target?.staticType?.element is! EnumElement) return;
+      if (node.propertyName.name != 'name') return;
+
+      reporter.atNode(node, _code);
     });
   }
 

--- a/packages/nilts/lib/src/lints/unstable_enum_values.dart
+++ b/packages/nilts/lib/src/lints/unstable_enum_values.dart
@@ -1,0 +1,71 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A class for `unstable_enum_values` rule.
+///
+/// This rule checks if `values` property is used to get the list of enum values.
+///
+/// - Target SDK     : Any versions nilts supports
+/// - Rule type      : Practice
+/// - Maturity level : Experimental
+/// - Quick fix      : ❌
+///
+/// **Consider** using a more stable way to handle enum values.
+/// The `values` property returns a mutable List, which can be modified
+/// and may cause unexpected behavior.
+///
+/// **BAD:**
+/// ```dart
+/// enum Color { red, green, blue }
+///
+/// void printColors() {
+///   for (final color in Color.values) {
+///     print(color);
+///   }
+/// }
+/// ```
+///
+/// **GOOD:**
+/// ```dart
+/// enum Color { red, green, blue }
+///
+/// void printColors() {
+///   final colors = [Color.red, Color.green, Color.blue];
+///   for (final color in colors) {
+///     print(color);
+///   }
+/// }
+/// ```
+///
+/// See also:
+///
+/// - [Enums - Dart language specification](https://dart.dev/language/enums)
+class UnstableEnumValues extends DartLintRule {
+  /// Create a new instance of [UnstableEnumValues].
+  const UnstableEnumValues() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'unstable_enum_values',
+    problemMessage: 'Do not use enum values property directly',
+    url: 'https://github.com/dassssshers/nilts#unstable_enum_values',
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addPrefixedIdentifier((node) {
+      if (node.identifier.name == 'values' &&
+          node.prefix.staticElement is EnumElement &&
+          (node.prefix.staticElement?.isPublic ?? true)) {
+        reporter.atNode(node, _code, arguments: []);
+      }
+    });
+  }
+
+  @override
+  List<Fix> getFixes() => [];
+}

--- a/packages/nilts/lib/src/lints/unstable_enum_values.dart
+++ b/packages/nilts/lib/src/lints/unstable_enum_values.dart
@@ -4,7 +4,7 @@ import 'package:custom_lint_builder/custom_lint_builder.dart';
 
 /// A class for `unstable_enum_values` rule.
 ///
-/// This rule checks if `values` property is used to get the list of enum values.
+/// This rule checks if `values` property is used to get from enum values.
 ///
 /// - Target SDK     : Any versions nilts supports
 /// - Rule type      : Practice

--- a/packages/nilts/lib/src/lints/unstable_enum_values.dart
+++ b/packages/nilts/lib/src/lints/unstable_enum_values.dart
@@ -40,14 +40,14 @@ import 'package:custom_lint_builder/custom_lint_builder.dart';
 ///
 /// See also:
 ///
-/// - [Enums - Dart language specification](https://dart.dev/language/enums)
+/// - [Enums | Dart](https://dart.dev/language/enums)
 class UnstableEnumValues extends DartLintRule {
   /// Create a new instance of [UnstableEnumValues].
   const UnstableEnumValues() : super(code: _code);
 
   static const _code = LintCode(
     name: 'unstable_enum_values',
-    problemMessage: 'Do not use enum values property directly',
+    problemMessage: 'enum values property is unstable',
     url: 'https://github.com/dassssshers/nilts#unstable_enum_values',
   );
 

--- a/packages/nilts/lib/src/lints/unstable_enum_values.dart
+++ b/packages/nilts/lib/src/lints/unstable_enum_values.dart
@@ -58,11 +58,12 @@ class UnstableEnumValues extends DartLintRule {
     CustomLintContext context,
   ) {
     context.registry.addPrefixedIdentifier((node) {
-      if (node.identifier.name == 'values' &&
-          node.prefix.staticElement is EnumElement &&
-          (node.prefix.staticElement?.isPublic ?? true)) {
-        reporter.atNode(node, _code, arguments: []);
-      }
+      final staticElement = node.prefix.staticElement;
+      if (staticElement is! EnumElement) return;
+      if (!staticElement.isPublic) return;
+      if (node.identifier.name != 'values') return;
+
+      reporter.atNode(node, _code);
     });
   }
 

--- a/packages/nilts_test/test/lints/unstable_enum_name.dart
+++ b/packages/nilts_test/test/lints/unstable_enum_name.dart
@@ -1,14 +1,13 @@
 enum Hoge {
   a,
   b,
-  c,
-  ;
+  c;
 
   String get id => switch (this) {
-        a => 'a',
-        b => 'b',
-        c => 'c',
-      };
+    a => 'a',
+    b => 'b',
+    c => 'c',
+  };
 }
 
 // expect_lint: unstable_enum_name

--- a/packages/nilts_test/test/lints/unstable_enum_name.dart
+++ b/packages/nilts_test/test/lints/unstable_enum_name.dart
@@ -1,0 +1,17 @@
+enum Hoge {
+  a,
+  b,
+  c,
+  ;
+
+  String get id => switch (this) {
+        a => 'a',
+        b => 'b',
+        c => 'c',
+      };
+}
+
+// expect_lint: unstable_enum_name
+final name = Hoge.a.name;
+
+final id = Hoge.a.id;

--- a/packages/nilts_test/test/lints/unstable_enum_values.dart
+++ b/packages/nilts_test/test/lints/unstable_enum_values.dart
@@ -1,8 +1,4 @@
-enum Hoge {
-  a,
-  b,
-  c,
-}
+enum Hoge { a, b, c }
 
 // expect_lint: unstable_enum_values
 const errorValues = Hoge.values;
@@ -10,8 +6,7 @@ const errorValues = Hoge.values;
 enum _Fuga {
   a,
   b,
-  c,
-  ;
+  c;
 
   static List<_Fuga> get staticValues => [_Fuga.a, _Fuga.b, _Fuga.c];
 }

--- a/packages/nilts_test/test/lints/unstable_enum_values.dart
+++ b/packages/nilts_test/test/lints/unstable_enum_values.dart
@@ -3,12 +3,16 @@ enum Hoge { a, b, c }
 // expect_lint: unstable_enum_values
 const errorValues = Hoge.values;
 
-enum _Fuga {
+enum Fuga {
   a,
   b,
   c;
 
-  static List<_Fuga> get staticValues => [_Fuga.a, _Fuga.b, _Fuga.c];
+  static List<Fuga> get staticValues => [Fuga.a, Fuga.b, Fuga.c];
 }
 
-final errorValues2 = _Fuga.staticValues;
+final errorValues2 = Fuga.staticValues;
+
+enum _Hoo { a, b, c }
+
+const errorValues3 = _Hoo.values;

--- a/packages/nilts_test/test/lints/unstable_enum_values.dart
+++ b/packages/nilts_test/test/lints/unstable_enum_values.dart
@@ -1,0 +1,19 @@
+enum Hoge {
+  a,
+  b,
+  c,
+}
+
+// expect_lint: unstable_enum_values
+const errorValues = Hoge.values;
+
+enum _Fuga {
+  a,
+  b,
+  c,
+  ;
+
+  static List<_Fuga> get staticValues => [_Fuga.a, _Fuga.b, _Fuga.c];
+}
+
+final errorValues2 = _Fuga.staticValues;


### PR DESCRIPTION
## Overview

add rule for `unstable_enum_values` & `unstable_enum_name`

This rule is hard to add quick fix feature. If there's any problem please let me know.

## Feature type

<!-- Select which type of feature you want to add. -->

- [x] Lint Rule
- [ ] Quick fix
- [ ] Assist
- [ ] Other (Update docs, Configure CI, etc...)

## Checklist

<!-- Please check all of the followings before submitting your PR -->

- [x] I have read the [CONTRIBUTING](https://github.com/dassssshers/nilts/blob/main/CONTRIBUTING.md) docs.
- [x] I have written an related issue or linked with existing issues.
- [x] I have written tests and passed all of them.
    - Use `melos test` to run tests.
- [x] I have updated docs (if needed).
