### PR TITLE
clean: sdk version constraint for unnecessary_rebuilds_from_media_query

### DIFF
--- a/packages/nilts/README.md
+++ b/packages/nilts/README.md
@@ -115,7 +115,7 @@ Some of lint rules support quick fixes on IDE.
 | [no_support_web_platform_check](#no_support_web_platform_check)                 | Checks if `Platform.isXxx` usages.                                             |  Any versions nilts supports   | Practice  |  Experimental  |    ✅️    |
 | [open_type_hierarchy](#open_type_hierarchy)                                     | Checks if class modifiers exsist (final, sealed, etc.)                         |  Any versions nilts supports   | Practice  |  Experimental  |    ✅️    |
 | [shrink_wrapped_scroll_view](#shrink_wrapped_scroll_view)                       | Checks the content of the scroll view is shrink wrapped.                       |  Any versions nilts supports   | Practice  |  Experimental  |    ✅️    |
-| [unnecessary_rebuilds_from_media_query](#unnecessary_rebuilds_from_media_query) | Checks `MediaQuery.xxxOf(context)` or `MediaQuery.maybeXxxOf(context)` usages. | >= Flutter 3.10.0 (Dart 3.0.0) | Practice  |  Experimental  |    ✅️    |
+| [unnecessary_rebuilds_from_media_query](#unnecessary_rebuilds_from_media_query) | Checks `MediaQuery.xxxOf(context)` or `MediaQuery.maybeXxxOf(context)` usages. |  Any versions nilts supports   | Practice  |  Experimental  |    ✅️    |
 | [unsafe_null_assertion](#unsafe_null_assertion)                                 | Checks usage of the `!` operator for forced type casting.                      |  Any versions nilts supports   | Practice  |  Experimental  |    ✅️    |
 
 ### Details
@@ -722,7 +722,7 @@ See also:
 <details>
 
 <!-- prettier-ignore-start -->
-- Target SDK     : >= Flutter 3.10.0 (Dart 3.0.0)
+- Target SDK     : Any versions nilts supports 
 - Rule type      : Practice
 - Maturity level : Experimental
 - Quick fix      : ✅

--- a/packages/nilts/lib/nilts.dart
+++ b/packages/nilts/lib/nilts.dart
@@ -44,8 +44,7 @@ class _NiltsLint extends PluginBase {
         const NoSupportWebPlatformCheck(),
         const OpenTypeHierarchy(),
         const ShrinkWrappedScrollView(),
-        if (_dartVersion >= const DartVersion(major: 3, minor: 0, patch: 0))
-          UnnecessaryRebuildsFromMediaQuery(_dartVersion),
+        UnnecessaryRebuildsFromMediaQuery(_dartVersion),
         const UnsafeNullAssertion(),
       ];
 }

--- a/packages/nilts/lib/src/lints/unnecessary_rebuilds_from_media_query.dart
+++ b/packages/nilts/lib/src/lints/unnecessary_rebuilds_from_media_query.dart
@@ -14,7 +14,7 @@ import 'package:nilts_core/nilts_core.dart';
 /// [MediaQuery.of] or [MediaQuery.maybeOf] is used
 /// instead of `MediaQuery.xxxOf` or `MediaQuery.maybeXxxOf`.
 ///
-/// - Target SDK     : >= Flutter 3.10.0 (Dart 3.0.0)
+/// - Target SDK     : Any versions nilts supports
 /// - Rule type      : Practice
 /// - Maturity level : Experimental
 /// - Quick fix      : ✅


### PR DESCRIPTION
## Overview

- remove sdk version constraint for unnecessary_rebuilds_from_media_query

<!-- Summarize what do you want add in this PR. -->

## Feature type

<!-- Select which type of feature you want to add. -->

- [x] Lint Rule
- [ ] Quick fix
- [ ] Assist
- [ ] Other (Update docs, Configure CI, etc...)